### PR TITLE
Fix Firebase Storage deployment error

### DIFF
--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -42,7 +42,7 @@ jobs:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_DEPLOY_TOKEN }}
 
       - name: Deploy Storage Rules
-        run: firebase deploy --only storage:rules --project skinscore-afw5a
+        run: firebase deploy --only storage --project skinscore-afw5a
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_DEPLOY_TOKEN }}
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,7 +1,4 @@
 {
-  "projects": {
-    "default": "skinscore-afw5a"
-  },
   "hosting": {
     "public": "dist",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],


### PR DESCRIPTION
- Fix workflow command: change 'storage:rules' to 'storage'
- Remove duplicate 'projects' property from firebase.json (already in .firebaserc)
- Firebase doesn't recognize 'storage:rules' as a valid deployment target
- The correct command is 'firebase deploy --only storage'

This fixes the 'Could not find rules for the following storage targets: rules' error that was causing the Deploy Firebase Services workflow to fail.

🤖 Generated with [Claude Code](https://claude.ai/code)